### PR TITLE
Implement version caching for romupdate

### DIFF
--- a/luasrc/view/romupdate.htm
+++ b/luasrc/view/romupdate.htm
@@ -1,11 +1,23 @@
 <%+header%>
 <%
 local sys = require "luci.sys"
+local fs  = require "nixio.fs"
 -- 获取当前系统版本（去除换行）
 local current_version = sys.exec("cat /etc/lenyu_version"):gsub("\n", "")
 
--- 从 GitHub 获取最新版本并保存到 /usr/share/cloud_ts_version
-os.execute('wget -qO- -t1 -T2 "https://api.github.com/repos/Blueplanet20120/immortalwrt-86/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" \'{print $2}\' | sed \'s/\"//g;s/,//g;s/ //g\' > /usr/share/cloud_ts_version')
+local version_file = "/usr/share/cloud_ts_version"
+local stat = fs.stat(version_file)
+local need_fetch = true
+
+-- 如果缓存文件存在且在 10 分钟内更新过，则直接使用缓存
+if stat and stat.mtime and os.time() - stat.mtime < 600 then
+    need_fetch = false
+end
+
+if need_fetch then
+    os.execute('wget -qO- -t1 -T2 "https://api.github.com/repos/Blueplanet20120/immortalwrt-86/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" \'{print $2}\' | sed \'s/\"//g;s/,//g;s/ //g\' > ' .. version_file)
+end
+
 
 -- 读取云端版本（仅保留 "_" 前部分）
 local cloud_version = sys.exec("cat /usr/share/cloud_ts_version | cut -d '_' -f 1"):gsub("\n", "")


### PR DESCRIPTION
## Summary
- cache fetched version in `/usr/share/cloud_ts_version`
- avoid downloading version info on every page load
- refresh the cached value every 10 minutes

## Testing
- `make` *(fails: luci.mk missing)*


------
https://chatgpt.com/codex/tasks/task_e_6845800f797c8321a47f402dbb495b14