### PR TITLE
Fix romupdate init script

### DIFF
--- a/root/etc/init.d/romupdate
+++ b/root/etc/init.d/romupdate
@@ -5,16 +5,8 @@ run_autoupdate() {
   local enable
   config_get_bool enable "$1" enable
   if [ "$enable" = "1" ]; then
-    local minute
-    local hour
-    config_get week "$1" week
-    config_get minute "$1" minute
-    config_get hour "$1" hour
-
-    [ "$minute" = "0" ] && minute="00"
-    [ "$week" = "7" ] && week="*"
     sed -i '/Lenyu/d' /etc/crontabs/root >/dev/null 2>&1
-    echo "$minute $hour * * $week sh /usr/share/Lenyu-auto.sh -u" >>/etc/crontabs/root
+    echo "0 0 * * * sh /usr/share/Lenyu-auto.sh -u" >>/etc/crontabs/root
   else
     sed -i '/Lenyu/d' /etc/crontabs/root >/dev/null 2>&1
   fi
@@ -24,7 +16,7 @@ run_autoupdate() {
 
 start() {
   config_load romupdate
-  config_foreach run_autoupdate login
+  config_foreach run_autoupdate general
 }
 
 stop() {


### PR DESCRIPTION
## Summary
- update romupdate init script to reference correct config section
- drop unused schedule options
- ensure script is executable

## Testing
- `make` *(fails: `/feeds/luci/luci.mk: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68457f3d12208321be5aaf6c8ebaba4e